### PR TITLE
Custom App Plan & Regex Pattern Escape Characters

### DIFF
--- a/Build/Bicep/FunctionApps.bicep
+++ b/Build/Bicep/FunctionApps.bicep
@@ -87,6 +87,13 @@ param ReplaceSessionHostOnNewImageVersion bool = true
 
 @description('Required: No | Delay in days before replacing session hosts when a new image version is detected. | Default: 0 (no delay).')
 param ReplaceSessionHostOnNewImageVersionDelayDays int = 0
+
+@description('Required: No | App Service Plan Name | Default Y1 for consumption based plan')
+param AppPlanName string = 'Y1'
+
+@description('Required: No | App Service Plan Tier | Default Dynamic for consumption based plan')
+param AppPlanTier string = 'Dynamic'
+
 //-------//
 
 //------ Variables ------//
@@ -248,8 +255,8 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   name: varAppServicePlanName
   location: Location
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: AppPlanName
+    tier: AppPlanTier
   }
 }
 

--- a/FunctionApp/Modules/SessionHostReplacer/functions/Get-SHRLatestImageVersion.ps1
+++ b/FunctionApp/Modules/SessionHostReplacer/functions/Get-SHRLatestImageVersion.ps1
@@ -37,8 +37,8 @@ function Get-SHRLatestImageVersion {
     elseif ($ImageReference.Id) {
         # Shared Image Gallery
         Write-PSFMessage -Level Host -Message 'Image is from Shared Image Gallery: {0}' -StringValues $ImageReference.Id
-        $imageDefinitionResourceIdPattern = '^\/subscriptions\/(?<subscription>[a-z0-9\-]+)\/resourceGroups\/(?<resourceGroup>[^/]+)\/providers\/Microsoft\.Compute\/galleries\/(?<gallery>[^/]+)\/images\/(?<image>[^/]+)$'
-        $imageVersionResourceIdPattern = '^\/subscriptions\/(?<subscription>[a-z0-9\-]+)\/resourceGroups\/(?<resourceGroup>[^/]+)\/providers\/Microsoft\.Compute\/galleries\/(?<gallery>[^/]+)\/images\/(?<image>[^/]+)\/versions\/(?<version>[^/]+)$'
+        $imageDefinitionResourceIdPattern = '^\/subscriptions\/(?<subscription>[a-z0-9\-]+)\/resourceGroups\/(?<resourceGroup>[^\/]+)\/providers\/Microsoft\.Compute\/galleries\/(?<gallery>[^\/]+)\/images\/(?<image>[^\/]+)$'
+        $imageVersionResourceIdPattern = '^\/subscriptions\/(?<subscription>[a-z0-9\-]+)\/resourceGroups\/(?<resourceGroup>[^\/]+)\/providers\/Microsoft\.Compute\/galleries\/(?<gallery>[^\/]+)\/images\/(?<image>[^\/]+)\/versions\/(?<version>[^\/]+)$'
         if ($ImageReference.Id -match $imageDefinitionResourceIdPattern) {
             Write-PSFMessage -Level Host -Message 'Image reference is an Image Definition resource.'
             $imageSubscriptionId = $Matches.subscription


### PR DESCRIPTION
Hi Walid,

I was running through the shared image gallery changes and was running in to failures with escape characters in the Regex pattern in Get-SHRLatestImageVersion function.

I've also added inputs and variables setting a custom app plan while leaving the defaults to 'consumption based' and 'dynamic'.