### PR TITLE
Public Samples Using Split Resource Deployment

### DIFF
--- a/Build/Bicep/Deploy-App-Plan.bicep
+++ b/Build/Bicep/Deploy-App-Plan.bicep
@@ -1,0 +1,77 @@
+/*
+This solution is made up of:
+1- AppServicePlan - Used to host all functions
+2- StorageAccount - To store FunctionApp
+3- LogAnalyticsWorkspace - Used to store Logs, and AppService insights
+*/
+
+//------ Parameters ------//
+@description('Required: No | Region of the Function App. This does not need to be the same as the location of the Azure Virtual Desktop Host Pool. | Default: Location of the resource group.')
+param Location string = resourceGroup().location
+//Storage Account
+@description('Required: Yes | Name of the storage account used by the Function App. This name must be unique across all existing storage account names in Azure. It must be 3 to 24 characters in length and use numbers and lower-case letters only.')
+param StorageAccountName string
+//Log Analytics Workspace
+@description('Required: Yes | Name of the Log Analytics Workspace used by the Function App Insights.')
+param LogAnalyticsWorkspaceName string
+
+@description('Required: Yes | Name of the Log Analytics Workspace used by the Function App Insights.')
+param AppServicePlanName string
+
+@description('Required: No | App Service Plan Name | Default Y1 for consumption based plan')
+param AppPlanName string = 'Y1'
+
+@description('Required: No | App Service Plan Tier | Default Dynamic for consumption based plan')
+param AppPlanTier string = 'Dynamic'
+
+//-------//
+
+//------ Resources ------//
+
+// Deploy Storage Account
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+  name: StorageAccountName
+  location: Location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    // TODO: Discuss securing the storage account (firewall)
+  }
+}
+
+// Deploy Log Analytics Workspace
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
+  name: LogAnalyticsWorkspaceName
+  location: Location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Deploy App Service Plan
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+  name: AppServicePlanName
+  location: Location
+  sku: {
+    name: AppPlanName
+    tier: AppPlanTier
+  }
+}
+
+// Deploy App Insights for App Service Plan
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: AppServicePlanName
+  location: Location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}

--- a/Build/Bicep/Deploy-App-Plan.ps1
+++ b/Build/Bicep/Deploy-App-Plan.ps1
@@ -1,0 +1,27 @@
+$ResourceGroupName = 'rg-us1-prd-avd-session-host-functions'
+$params = @{
+    SubscriptionId    = '<subscriptionn-id>'
+    ResourceGroupName = 'rg-us1-prd-vdi-avd-session-host-functions'
+    Location          = 'EastUs'
+    AssignPermissions = $false
+    BicepParams       = @{
+        #Storage Account
+        StorageAccountName                  = '<storage-account-name>'
+
+        #Log Analytics Workspace
+        LogAnalyticsWorkspaceName           = '<log-anayltics-workspace-name>'
+        #FunctionApp
+        AppServicePlanName                  = '<app-service-plan-name>'
+    }
+}
+
+$paramsNewAzResourceGroupDeployment = @{
+    # Cmdlet parameters
+    TemplateFile            = ".\Build\Bicep\Deploy-App-Plan.bicep"
+    AppPlanName             = 'B1'
+    AppPlanTier             = 'Basic'
+    ResourceGroupName       = $ResourceGroupName
+    TemplateParameterObject = $params.BicepParams
+}
+
+New-AzResourceGroupDeployment @paramsNewAzResourceGroupDeployment -Verbose

--- a/Build/Bicep/Deploy-Function-Only.bicep
+++ b/Build/Bicep/Deploy-Function-Only.bicep
@@ -1,0 +1,307 @@
+/*
+This solution is made up of:
+1- AppServicePlan - Existing App Service Plan used to host all functions
+2- Azure Function: New AVDSessionHostReplacer Function
+4- StorageAccount - Existing used to store FunctionApp
+5- LogAnalyticsWorkspace - Existing used to store Logs, and AppService insights
+*/
+
+//------ Parameters ------//
+@description('Required: No | Region of the Function App. This does not need to be the same as the location of the Azure Virtual Desktop Host Pool. | Default: Location of the resource group.')
+param Location string = resourceGroup().location
+
+//Storage Account
+@description('Required: Yes | Name of the storage account used by the Function App. This name must be unique across all existing storage account names in Azure. It must be 3 to 24 characters in length and use numbers and lower-case letters only.')
+param StorageAccountName string
+
+@description('Required: Yes | Name of resource group to contain the Function App.')
+param ResourceGroupName string
+
+//Log Analytics Workspace
+@description('Required: Yes | Name of the Log Analytics Workspace used by the Function App Insights.')
+param LogAnalyticsWorkspaceName string
+
+//FunctionApp
+@description('Required: Yes | Name of the Function App.')
+param FunctionAppName string
+
+@description('Required: No | Subscription ID of the Azure Virtual Desktop Host Pool. | Default: The subscription ID of the resource group.')
+param SubscriptionId string = subscription().subscriptionId
+
+@description('Required: No | Name of the resource group containing the Azure Virtual Desktop Host Pool. | Default: The resource group of the Function App.')
+param HostPoolResourceGroupName string = resourceGroup().name
+
+@description('Required: Yes | Name of the Azure Virtual Desktop Host Pool.')
+param HostPoolName string
+
+@description('Required: No | URL of the FunctionApp.zip file. This is the zip file containing the Function App code. | Default: The latest release of the Function App code.')
+param FunctionAppZipUrl string = 'https://github.com/Thomas-Butterfield/AVDReplacementPlans/releases/download/v0.1.4(beta)/FunctionApp-V0.1.4-beta.zip'
+
+@description('Required: No | If true, will apply tags for Include In Auto Replace and Deployment Timestamp to existing session hosts. This will not enable automatic deletion of existing session hosts. | Default: True.')
+param FixSessionHostTags bool = true
+
+@description('Required: No | Tag name used to indicate that a session host should be included in the automatic replacement process. | Default: IncludeInAutoReplace.')
+param TagIncludeInAutomation string = 'IncludeInAutoReplace'
+
+@description('Required: No | Tag name used to indicate the timestamp of the last deployment of a session host. | Default: AutoReplaceDeployTimestamp.')
+param TagDeployTimestamp string = 'AutoReplaceDeployTimestamp'
+
+@description('Required: No | Tag name used to indicate drain timestamp of session host pending deletion. | Default: AutoReplacePendingDrainTimestamp.')
+param TagPendingDrainTimestamp string = 'AutoReplacePendingDrainTimestamp'
+
+@description('Required: No | Tag name used to exclude session host from Scaling Plan activities. | Default: None')
+param TagScalingPlanExclusionTag string = ' ' //This is a string with a single space.
+
+@description('Required: No | Target age of session hosts in days. | Default:  45 days.')
+param TargetVMAgeDays int = 45
+
+@description('Required: No | Grace period in hours for session hosts to drain before deletion. | Default: 24 hours.')
+param DrainGracePeriodHours int = 24
+
+@description('Required: No | Prefix used for the deployment name of the session hosts. | Default: AVDSessionHostReplacer')
+param SHRDeploymentPrefix string = 'AVDSessionHostReplacer'
+
+@description('Required: Yes | Number of session hosts to maintain in the host pool.')
+param TargetSessionHostCount int
+
+@description('Required: No | Maximum number of session hosts to deploy at the same time. | Default: 20')
+param MaxSimultaneousDeployments int = 20
+
+@description('Required: Yes | Prefix used for the name of the session hosts.')
+param SessionHostNamePrefix string
+
+@description('Required: Yes | URI of the arm template used to deploy the session hosts.')
+param SessionHostTemplateUri string
+
+@description('Required: Yes | A compressed (one line) json string containing the parameters of the template used to deploy the session hosts.')
+param SessionHostParameters string
+
+@description('Required: Yes, for Active Directory Domain Services | Distinguished Name of the OU to join session hosts to.')
+param ADOrganizationalUnitPath string = ''
+
+@description('Required: Yes | Resource ID of the subnet to deploy session hosts to.')
+param SubnetId string
+
+@description('Required: No | Number of digits to use for the instance number of the session hosts (eg. AVDVM-01). | Default: 2')
+param SessionHostInstanceNumberPadding int = 2
+
+@description('Required: No | If true, will replace session hosts when a new image version is detected. | Default: true')
+param ReplaceSessionHostOnNewImageVersion bool = true
+
+@description('Required: No | Delay in days before replacing session hosts when a new image version is detected. | Default: 0 (no delay).')
+param ReplaceSessionHostOnNewImageVersionDelayDays int = 0
+
+@description('Required: Yes | Name of the existing App Service Plan used by the Function App.')
+param AppServicePlanName string
+
+@description('Required: No | Resource ID of the subnet to deploy Azure Function to private vNet integration.')
+param functionSubnetId string
+
+@description('Required: Yes | Resource ID of the KeyVault containing the AVDDomainJoin secret.')
+param keyVaultName string
+
+@description('Required: Yes | Resource Group containing KeyVault with AVDDomainJoin secret.')
+param keyVaultResourceGroup string
+
+//-------//
+
+//------ Variables ------//
+var varFunctionAppSettings = [
+  {
+    name: 'FUNCTIONS_EXTENSION_VERSION'
+    value: '~4'
+  }
+  {
+    name: 'FUNCTIONS_WORKER_RUNTIME'
+    value: 'powershell'
+  }
+  {
+    name: 'AzureWebJobsStorage'
+    value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+  }
+  {
+    name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
+    value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+  }
+  {
+    name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+    value: appInsights.properties.InstrumentationKey
+  }
+  {
+    name: 'WEBSITE_CONTENTSHARE'
+    value: toLower(FunctionAppName)
+  }
+  {
+    name: '_FixSessionHostTags'
+    value: FixSessionHostTags
+  }
+  {
+    name: '_HostPoolResourceGroupName'
+    value: HostPoolResourceGroupName
+  }
+  {
+    name: '_HostPoolName'
+    value: HostPoolName
+  }
+  {
+    name: '_SHRDeploymentPrefix'
+    value: SHRDeploymentPrefix
+  }
+  {
+    name: '_SessionHostNamePrefix'
+    value: SessionHostNamePrefix
+  }
+  {
+    name: '_SubscriptionId'
+    value: SubscriptionId
+  }
+  {
+    name: '_SessionHostTemplateUri'
+    value: SessionHostTemplateUri
+  }
+  {
+    name: '_SessionHostParameters'
+    value: SessionHostParameters
+  }
+  {
+    name: '_ADOrganizationalUnitPath'
+    value: ADOrganizationalUnitPath
+  }
+  {
+    name: '_SubnetId'
+    value: SubnetId
+  }
+  {
+    name: '_SessionHostInstanceNumberPadding'
+    value: SessionHostInstanceNumberPadding
+  }
+  {
+    name: '_TargetSessionHostCount'
+    value: TargetSessionHostCount
+  }
+  {
+    name: '_MaxSimultaneousDeployments'
+    value: MaxSimultaneousDeployments
+  }
+  {
+    name: '_Tag_IncludeInAutomation'
+    value: TagIncludeInAutomation
+  }
+  {
+    name: '_Tag_DeployTimestamp'
+    value: TagDeployTimestamp
+  }
+  {
+    name: '_Tag_PendingDrainTimestamp'
+    value: TagPendingDrainTimestamp
+  }
+  {
+    name: '_Tag_ScalingPlanExclusionTag'
+    value: TagScalingPlanExclusionTag
+  }
+  {
+    name: '_TargetVMAgeDays'
+    value: TargetVMAgeDays
+  }
+  {
+    name: '_DrainGracePeriodHours'
+    value: DrainGracePeriodHours
+  }
+  {
+    name: '_StorageAccountName'
+    value: StorageAccountName
+  }
+  {
+    name: '_WorkspaceID'
+    value: logAnalyticsWorkspace.properties.customerId
+  }
+  {
+    name: '_WorkspaceKey'
+    value: logAnalyticsWorkspace.listkeys().primarySharedKey
+  }
+  {
+    name: '_ReplaceSessionHostOnNewImageVersion'
+    value: ReplaceSessionHostOnNewImageVersion
+  }
+  {
+    name: '_ReplaceSessionHostOnNewImageVersionDelayDays'
+    value: ReplaceSessionHostOnNewImageVersionDelayDays
+  }
+]
+
+//-------//
+
+//------ Resources ------//
+
+// Deploy Storage Account
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' existing = {
+  name: StorageAccountName
+  scope: resourceGroup(ResourceGroupName)
+}
+
+// Deploy Log Analytics Workspace
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
+  name: LogAnalyticsWorkspaceName
+  scope: resourceGroup(ResourceGroupName)
+}
+
+// Deploy App Service Plan
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' existing = {
+  name: AppServicePlanName
+  scope: resourceGroup(ResourceGroupName)
+}
+
+// Deploy App Insights for App Service Plan
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: AppServicePlanName
+  scope: resourceGroup(ResourceGroupName)
+}
+
+// Create ReplaceSessionHost function with Managed System Identity (MSI)
+resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
+  name: FunctionAppName
+  location: Location
+  kind: 'functionApp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    virtualNetworkSubnetId: functionSubnetId
+    httpsOnly: true
+    serverFarmId: appServicePlan.id
+    siteConfig: {
+      use32BitWorkerProcess: false
+      powerShellVersion: '7.2'
+      netFrameworkVersion: 'v6.0'
+      appSettings: varFunctionAppSettings
+    }
+  }
+
+  resource deployFromZip 'extensions@2022-03-01' = {
+    name: 'MSDeploy'
+    properties: {
+      packageUri: FunctionAppZipUrl
+    }
+  }
+}
+
+module RBACFunctionAppContributor 'modules/RBACRoleAssignment-Subscription.bicep' = {
+  name: 'RBACFunctionAppContributor'
+  scope: subscription()
+  params: {
+    PrinicpalId: functionApp.identity.principalId
+    RoleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c' // Subscription Contributor
+    SubscriptionId: SubscriptionId
+  }
+}
+
+module kvaccesspolicy 'modules/KeyVaultAccessPolicy.bicep' = {
+  name: 'kvaccesspolicy'
+  scope:  resourceGroup(keyVaultResourceGroup)
+  params: {
+    keyvaultName: keyVaultName
+    objectId: functionApp.identity.principalId
+  }
+}
+
+//------//

--- a/Build/Bicep/Deploy-Function-Only.ps1
+++ b/Build/Bicep/Deploy-Function-Only.ps1
@@ -1,0 +1,96 @@
+# This script assumes you have pre-deployed the required app service plan, storage account and log analytics workspace within your subscription.
+
+$ResourceGroupName = 'rg-us1-avd-session-host-functions'
+$params = @{
+
+    SubscriptionId    = '<subscription-id>'
+    ResourceGroupName = 'rg-us1-avd-session-host-functions' # Resource group where you want to create the function app
+    Location          = 'EastUs'
+    AssignPermissions = $false
+    BicepParams       = @{
+
+        # Existing Storage Account
+        StorageAccountName                  = '<storage-account-name>'
+
+        # Existing Log Analytics Workspace
+        LogAnalyticsWorkspaceName           = '<log-analytics-name>'
+
+        #Existing App Service Plan Name
+        AppServicePlanName                  = '<app-plan-name>'
+
+        # Existing Subnet Name | Required if private vNet integration is required
+        functionSubnetId                    = '/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/virtualNetworks/<vnet-name>/subnets/<subnet-name>' # Must be /28 and delegated to Azure Function
+        # Key Vault Name
+        keyVaultName                        = '<kv-name>'
+        # Key Vault Resource Group
+        keyVaultResourceGroup               = '<kv-rg>'
+        #FunctionApp Name
+        FunctionAppName                     = '<function-name>'
+
+        # AVD Settings
+        HostPoolResourceGroupName           = '<hostpool-rg>'
+        HostPoolName                        = '<hostpool-name>'
+        TagIncludeInAutomation              = 'IncludeInAutoReplace'
+        TagDeployTimestamp                  = 'AutoReplaceDeployTimestamp'
+        TagPendingDrainTimestamp            = 'AutoReplacePendingDrainTimestamp'
+        TargetVMAgeDays                     = 30
+        TagScalingPlanExclusionTag          = 'ExcludeReplacement'
+        DrainGracePeriodHours               = 12
+        FixSessionHostTags                  = $true
+        SHRDeploymentPrefix                 = "AVDSessionHostReplacer"
+        TargetSessionHostCount              = 1
+        MaxSimultaneousDeployments          = 2
+        SessionHostNamePrefix               = "<host-name>"
+        SessionHostTemplateUri              = "https://raw.githubusercontent.com/WillyMoselhy/AVDReplacementPlans/main/SampleSessionHostTemplate/sessionhost.json"
+        FunctionAppZipUrl                   = 'https://github.com/Thomas-Butterfield/AVDReplacementPlans/releases/download/v0.1.4(beta)/FunctionApp-V0.1.4-beta.zip'
+        ADOrganizationalUnitPath            = '<ad-ou-path>'
+        SubnetId                            = "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/virtualNetworks/<vnet-name>/subnets/<subnet-name>"
+        SessionHostInstanceNumberPadding    = 2 # This results in a session host name like AVD-WE-D01-01,02,03
+
+        # Session Host Parameters
+        SessionHostParameters = @{
+            VMSize                = 'Standard_E8ds_v5'
+            TimeZone              = 'Central Standard Time'
+            AdminUsername         = 'AVDAdmin'
+
+            #AvailabilityZone      = '1' #TODO Distribute on AZs if supported
+
+            AcceleratedNetworking = $true
+
+            Tags                  = @{}
+
+            ImageReference        = @{
+                Id = '/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/galleries/<gallery-name>/images/<image-definition>'
+            }
+
+            WVDArtifactsURL       = 'https://wvdportalstorageblob.blob.core.windows.net/galleryartifacts/Configuration_09-08-2022.zip'
+
+            #Domain Join
+            DomainJoinObject      = @{
+                DomainType = 'ActiveDirectory' # ActiveDirectory or AzureActiveDirectory
+                DomainName = 'contoso.com'
+                OUPath     = '<ad-ou-path>'
+                UserName   = '<username>'
+            }
+            DomainJoinPassword    = @{
+                reference = @{
+                    keyVault = @{
+                        id         = '/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.KeyVault/vaults/<kv-name>'
+                    }
+                    secretName = 'AVDDomainJoin'
+                }
+            }
+        }
+    }
+}
+
+$params.BicepParams.SessionHostParameters = $params.BicepParams.SessionHostParameters | ConvertTo-Json -Depth 10 -Compress
+$paramsNewAzResourceGroupDeployment = @{
+    # Cmdlet parameters
+    TemplateFile            = ".\Build\Bicep\Deploy-Function-Only.bicep"
+    Name                    = "DeployFunctionApp-$($params.BicepParams.FunctionAppName)"
+    ResourceGroupName       = $ResourceGroupName
+    TemplateParameterObject = $params.BicepParams
+}
+
+New-AzResourceGroupDeployment @paramsNewAzResourceGroupDeployment -Verbose

--- a/Build/Bicep/Modules/KeyVaultAccessPolicy.bicep
+++ b/Build/Bicep/Modules/KeyVaultAccessPolicy.bicep
@@ -1,0 +1,23 @@
+@description('Required: Yes | Resource ID of the KeyVault containing the AVDDomainJoin secret.')
+param keyvaultName string
+
+@description('Required: Yes | System Managed Id of function app to be assigned a new keyvault access policy')
+param objectId string
+
+resource accessPolicies 'Microsoft.KeyVault/vaults/accessPolicies@2022-07-01' = {
+  name: '${keyvaultName}/add'
+  properties: {
+    accessPolicies: [
+      {
+        objectId: objectId
+        tenantId: subscription().tenantId
+        permissions: {
+          secrets: [
+            'all'
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/Build/Bicep/Modules/RBACRoleAssignment-Subscription.bicep
+++ b/Build/Bicep/Modules/RBACRoleAssignment-Subscription.bicep
@@ -1,0 +1,14 @@
+param PrinicpalId string
+param RoleDefinitionId string
+param SubscriptionId string
+
+targetScope = 'subscription'
+
+resource RBACFunctionAppMSIhasVritualDesktopVMContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(SubscriptionId, PrinicpalId, RoleDefinitionId)
+  properties: {
+    principalId: PrinicpalId
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', RoleDefinitionId)
+  }
+}
+

--- a/Build/Bicep/Modules/RBACRoleAssignment-Subscription.bicep
+++ b/Build/Bicep/Modules/RBACRoleAssignment-Subscription.bicep
@@ -4,7 +4,7 @@ param SubscriptionId string
 
 targetScope = 'subscription'
 
-resource RBACFunctionAppMSIhasVritualDesktopVMContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource RBACFunctionAppMSIhasSubscriptionContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(SubscriptionId, PrinicpalId, RoleDefinitionId)
   properties: {
     principalId: PrinicpalId


### PR DESCRIPTION
Walid,

As discussed here are sample files for deploying the function app and required resources independent of each other.

I've also included the bicep modules which assign the function app RBAC at the subscription scope instead of resource group and the key vault access policy.

The function app in this example is using a basic app service plan to private vNet integration for retrieving secrets from a key-vault where public access is disabled.